### PR TITLE
fix collision check with v3 engine anchor system

### DIFF
--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -1184,13 +1184,13 @@ export enum AudioType {
 }
 
 function commonAreaFromSprite(e: g.E): g.CommonArea {
-	const topLeftOffset = e.localToGlobal({
+	const offset = e.localToGlobal({
 		x: 0,
 		y: 0
 	});
 	return {
-		x: topLeftOffset.x - e.anchorX * e.width,
-		y: topLeftOffset.y - e.anchorY * e.height,
+		x: offset.x - e.anchorX * e.width,
+		y: offset.y - e.anchorY * e.height,
 		width: e.width,
 		height: e.height
 	};

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -28,7 +28,7 @@ import {
 } from "./types/MessageEventType";
 import { UserTouchState } from "./types/UserTouchState";
 import { PlayerList } from "./types/PlayerList";
-import { Snake, SnakeType, SnakeSegmentType, SnakeRotateState, SnakeSegment } from "./entity/Snake";
+import { Snake, SnakeType, SnakeSegmentType, SnakeRotateState } from "./entity/Snake";
 import { sessionParameter } from "./config/defaultParameter";
 import { Food } from "./entity/Food";
 import { JewelData } from "./entity/Jewel";
@@ -540,18 +540,15 @@ export class StateManager {
 
 		/** スネークの頭同士の判定 */
 		const enemyHeadArea = commonAreaFromSprite(enemySnake.head);
-		collided = collided || g.Collision.withinAreas(playerHeadArea, enemyHeadArea, playerHeadArea.width);
+		collided = collided || g.Collision.withinAreas(playerHeadArea, enemyHeadArea, playerSnake.head.width);
 
 		/** あるスネークと敵スネーク節の当たり判定 */
 		enemySnake.segments.forEach(seg => {
 			if (seg.type === SnakeSegmentType.Jewel) return;
-			const enemyBodyArea: g.CommonArea = {
-				width: seg.body.width,
-				height: seg.body.height,
-				x: seg.x + seg.body.x,
-				y: seg.y + seg.body.y
-			};
-			collided = collided || g.Collision.withinAreas(playerHeadArea, enemyBodyArea, (seg.body.width + playerHeadArea.width) / 2);
+			const enemyBodyArea = commonAreaFromSprite(seg.body);
+			collided = collided || g.Collision.withinAreas(playerHeadArea, enemyBodyArea,
+				((seg.body.width + playerSnake.head.width) / 2)
+			);
 		});
 		return collided;
 	}
@@ -587,7 +584,7 @@ export class StateManager {
 				const playerHeadArea = commonAreaFromSprite(playerSnake.head);
 				if (
 					!isEaten &&
-					g.Collision.withinAreas(foodArea, playerHeadArea, (foodArea.width + playerHeadArea.height) / 2)
+					g.Collision.withinAreas(foodArea, playerHeadArea, (foodArea.width + playerSnake.head.width))
 				){
 					isEaten = true;
 					eatenFoodInfo.push({eaterId: playerId, eatenIndex: foodIndex});
@@ -1186,11 +1183,15 @@ export enum AudioType {
 	ResultBGM = "ResultBGM"
 }
 
-function commonAreaFromSprite(segment: SnakeSegment): g.CommonArea {
+function commonAreaFromSprite(e: g.E): g.CommonArea {
+	const topLeftOffset = e.localToGlobal({
+		x: 0,
+		y: 0
+	});
 	return {
-		width: segment.body.width * 0.8,
-		height: segment.body.height * 0.8,
-		x: segment.x + segment.body.x - segment.body.width / 2,
-		y: segment.y + segment.body.y - segment.body.height / 2
+		x: topLeftOffset.x - e.anchorX * e.width,
+		y: topLeftOffset.y - e.anchorY * e.height,
+		width: e.width,
+		height: e.height
 	};
 }


### PR DESCRIPTION
## このpull requestが解決する内容

<!-- Pull Requestの変更内容の概要を書いてください -->
スネークの当たり判定ロジックにおいて、 `anchorX/Y` が考慮されておらず、
描画内容と異なる位置で判定矩形が計算されていました。
そのため、見た目の位置と離れた箇所で当たり判定が発生していました。
これを解決するため、判定ロジックを修正します。

## 破壊的な変更を含んでいるか?

- あり
当たり判定の判定条件が変わるため、既存のバージョンのplaylogは正しく動作しません。

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

